### PR TITLE
Update the moquette version

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>io.moquette</groupId>
             <artifactId>moquette-broker</artifactId>
-            <version>0.8</version>
+            <version>${moquette.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttPublishTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttPublishTestCase.java
@@ -18,9 +18,9 @@
  */
 package io.siddhi.extension.io.mqtt.sink;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.exception.ConnectionUnavailableException;

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttSinkMapTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttSinkMapTest.java
@@ -18,9 +18,9 @@
  */
 package io.siddhi.extension.io.mqtt.sink;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.exception.ConnectionUnavailableException;

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttSinkQosTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttSinkQosTestCase.java
@@ -18,9 +18,9 @@
  */
 package io.siddhi.extension.io.mqtt.sink;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.exception.ConnectionUnavailableException;

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttSinkTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/sink/MqttSinkTestCase.java
@@ -19,9 +19,9 @@
 
 package io.siddhi.extension.io.mqtt.sink;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/source/MqttSourceMapTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/source/MqttSourceMapTest.java
@@ -18,9 +18,9 @@
  */
 package io.siddhi.extension.io.mqtt.source;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/source/MqttSourceQosTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/source/MqttSourceQosTest.java
@@ -18,9 +18,9 @@
  */
 package io.siddhi.extension.io.mqtt.source;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;

--- a/component/src/test/java/io/siddhi/extension/io/mqtt/source/MqttSourceTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/mqtt/source/MqttSourceTestCase.java
@@ -18,9 +18,9 @@
  */
 package io.siddhi.extension.io.mqtt.source;
 
-import io.moquette.server.Server;
-import io.moquette.server.config.IConfig;
-import io.moquette.server.config.MemoryConfig;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <paho.mqtt.version>1.2.1</paho.mqtt.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <siddhi.map.binary.version>2.1.1</siddhi.map.binary.version>
-        <moquette.version>0.12</moquette.version>
+        <moquette.version>0.15</moquette.version>
         <log4j.version>2.17.1</log4j.version>
         <json.mapper.version>5.2.2</json.mapper.version>
         <xml.mapper.version>5.2.2</xml.mapper.version>


### PR DESCRIPTION
## Purpose
The current build is failing due to the use of an outdated version of the `moquette` dependencies(version 0.8 and 0.12), which are no longer available. Updating to a newer version(0.15) to resolve the issue.