### PR TITLE
Update the parent pom

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/mqtt/sink/MqttSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/mqtt/sink/MqttSink.java
@@ -238,14 +238,14 @@ public class MqttSink extends Sink {
     public void disconnect() {
         try {
             client.disconnect();
-            log.debug("Disconnected from MQTT broker: " + brokerURL);
+            log.debug("Disconnected from MQTT broker: {}", brokerURL);
         } catch (MqttException e) {
-            log.error("Could not disconnect from MQTT broker: " + brokerURL, e);
+            log.error("Could not disconnect from MQTT broker: {}", brokerURL, e);
         } finally {
             try {
                 client.close();
             } catch (MqttException e) {
-                log.error("Could not close connection with MQTT broker: " + brokerURL, e);
+                log.error("Could not close connection with MQTT broker: {}", brokerURL, e);
             }
         }
     }
@@ -287,11 +287,11 @@ public class MqttSink extends Sink {
             String topic = topicOption.getValue(dynamicOptions);
             client.publish(topic, message);
         } catch (MqttException e) {
-            log.error("Error occurred when publishing message to the MQTT broker: " + brokerURL + " in "
-                    + streamDefinition.getId(), e);
+            log.error("Error occurred when publishing message to the MQTT broker: {} in {}", brokerURL,
+                    streamDefinition.getId(), e);
         } catch (UnsupportedEncodingException e) {
-            log.error("Event could not be encoded in UTF-8, hence it could not be published to MQTT broker: "
-                    + brokerURL + " in " + streamDefinition.getId(), e);
+            log.error("Event could not be encoded in UTF-8, hence it could not be published to MQTT broker: " +
+                    "{} in {}", brokerURL, streamDefinition.getId(), e);
         }
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/mqtt/source/MqttSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/mqtt/source/MqttSource.java
@@ -219,18 +219,16 @@ public class MqttSource extends Source {
     public void disconnect() {
         try {
             client.disconnect();
-            log.debug("Disconnected from MQTT broker: " + brokerURL + " defined in Siddhi App: " +
-                    siddhiAppName);
+            log.debug("Disconnected from MQTT broker: {} defined in Siddhi App: {}", brokerURL, siddhiAppName);
         } catch (MqttException e) {
-            log.error("Could not disconnect from MQTT broker: " + brokerURL + " defined in Siddhi App: " +
-                    siddhiAppName, e);
+            log.error("Could not disconnect from MQTT broker: {} defined in Siddhi App: {}",
+                    brokerURL, siddhiAppName, e);
         } finally {
             try {
                 client.close();
             } catch (MqttException e) {
-                log.error("Could not close connection with MQTT broker: " + brokerURL +
-                        " defined in Siddhi App: " +
-                        siddhiAppName, e);
+                log.error("Could not close connection with MQTT broker: {} defined in Siddhi App: {}",
+                        brokerURL, siddhiAppName, e);
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>5</version>
+        <version>5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Purpose

- With the current parent POM version, `http` URLs are being used to publish artifacts to Nexus, causing the build to fail. Updating the parent POM to use `https` URLs to resolve this issue.
- Fix the CRLF injection in log messages reported by SpotBugs after updating the parent pom.
