### PR TITLE
Fix error "no NetworkModule installed for scheme "tcp" of URI" when using mqtt extension

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -140,6 +140,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>unpack-dependency</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.paho</groupId>
+                                    <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+                                    <version>${paho.mqtt.version}</version>
+                                    <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <suiteXmlFiles>
@@ -172,6 +196,10 @@
                             META-INF=target/classes/META-INF
                         </Include-Resource>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Include-Resource>
+                            META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory=
+                            ${project.build.directory}/dependency/META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory
+                        </Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
         <json.mapper.version>5.2.2</json.mapper.version>
         <xml.mapper.version>5.2.2</xml.mapper.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
+        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose
$subject

## Approach
The spi services file is missing in the created jar. This services file is inside the paho.mqttt.client and this is added by extracting this jar and adding the services file inside that.