### PR TITLE
Fix mqtt network modules not loading

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -140,30 +140,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>unpack-dependency</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.eclipse.paho</groupId>
-                                    <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-                                    <version>${paho.mqtt.version}</version>
-                                    <outputDirectory>${project.build.directory}/dependency</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <suiteXmlFiles>
@@ -193,13 +169,10 @@
                             *;resolution:=optional
                         </Import-Package>
                         <Include-Resource>
-                            META-INF=target/classes/META-INF
+                            META-INF=target/classes/META-INF,
+                            {maven-resources}
                         </Include-Resource>
                         <DynamicImport-Package>*</DynamicImport-Package>
-                        <Include-Resource>
-                            META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory=
-                            ${project.build.directory}/dependency/META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory
-                        </Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -140,6 +140,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>unpack-dependency</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.paho</groupId>
+                                    <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+                                    <version>${paho.mqtt.version}</version>
+                                    <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <suiteXmlFiles>
@@ -172,6 +196,10 @@
                             META-INF=target/classes/META-INF
                         </Include-Resource>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Include-Resource>
+                            META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory=
+                            ${project.build.directory}/dependency/META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory
+                        </Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>

--- a/component/src/main/resources/META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory
+++ b/component/src/main/resources/META-INF/services/org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory
@@ -1,0 +1,4 @@
+org.eclipse.paho.client.mqttv3.internal.TCPNetworkModuleFactory
+org.eclipse.paho.client.mqttv3.internal.SSLNetworkModuleFactory
+org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketNetworkModuleFactory
+org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketSecureNetworkModuleFactory

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <properties>
         <siddhi.version>5.1.21</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
-        <paho.mqtt.version>1.2.1</paho.mqtt.version>
+        <paho.mqtt.version>1.2.5</paho.mqtt.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <siddhi.map.binary.version>2.1.1</siddhi.map.binary.version>
         <moquette.version>0.15</moquette.version>
@@ -151,6 +151,7 @@
         <json.mapper.version>5.2.2</json.mapper.version>
         <xml.mapper.version>5.2.2</xml.mapper.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
+        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <properties>
         <siddhi.version>5.1.21</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
-        <paho.mqtt.version>1.2.5</paho.mqtt.version>
+        <paho.mqtt.version>1.2.1</paho.mqtt.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <siddhi.map.binary.version>2.1.1</siddhi.map.binary.version>
         <moquette.version>0.15</moquette.version>
@@ -151,7 +151,6 @@
         <json.mapper.version>5.2.2</json.mapper.version>
         <xml.mapper.version>5.2.2</xml.mapper.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
-        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose

Fix the issue,
```
no NetworkModule installed for scheme "tcp" of URI "tcp://localhost:1883" Error while connecting at Source 'mqtt' at 'SweetProductionStream'. java.lang.IllegalArgumentException: no NetworkModule installed for scheme "tcp" of URI "tcp://localhost:1883"
        at org.eclipse.paho.client.mqttv3.internal.NetworkModuleService.validateURI(NetworkModuleService.java:70)
        at org.eclipse.paho.client.mqttv3.MqttAsyncClient.<init>(MqttAsyncClient.java:454)
        at org.eclipse.paho.client.mqttv3.MqttAsyncClient.<init>(MqttAsyncClient.java:320)
        at org.eclipse.paho.client.mqttv3.MqttAsyncClient.<init>(MqttAsyncClient.java:315)
```

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
This is due to Dynamic class loading in the runtime. The network modules in the `org.eclipse.paho.client.mqttv3.spi.NetworkModuleFactory` is registered

## Automation tests
Tested the following samples.
https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/ReceiveMQTTInXMLFormat/
https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/PublishMqttInXmlFormat/
